### PR TITLE
Fix fluent-ffmpeg type error in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "zustand": "^5.0.7"
     },
     "devDependencies": {
+        "@types/fluent-ffmpeg": "^2.1.27",
         "@biomejs/biome": "2.1.2",
         "@csstools/postcss-cascade-layers": "^5.0.2",
         "@tailwindcss/cli": "^4.1.11",
@@ -129,7 +130,7 @@
         "vitest-mock-extended": "^2.0.2"
     },
     "engines": {
-        "node": "22.16.0"
+        "node": "22"
     },
     "pnpm": {
         "overrides": {
@@ -144,6 +145,7 @@
             "@tailwindcss/oxide",
             "core-js",
             "esbuild",
+            "ffmpeg-static",
             "oxc-resolver",
             "prisma",
             "protobufjs",
@@ -152,5 +154,6 @@
             "tree-sitter-javascript",
             "tree-sitter-typescript"
         ]
-    }
+    },
+    "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@types/fluent-ffmpeg':
+        specifier: ^2.1.27
+        version: 2.1.27
       '@types/lodash.throttle':
         specifier: ^4.1.9
         version: 4.1.9
@@ -2751,6 +2754,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/fluent-ffmpeg@2.1.27':
+    resolution: {integrity: sha512-QiDWjihpUhriISNoBi2hJBRUUmoj/BMTYcfz+F+ZM9hHWBYABFAE6hjP/TbCZC0GWwlpa3FzvHH9RzFeRusZ7A==}
 
   '@types/lodash.throttle@4.1.9':
     resolution: {integrity: sha512-PCPVfpfueguWZQB7pJQK890F2scYKoDUL3iM522AptHWn7d5NQmeS/LTEHIcLr5PaTzl3dK2Z0xSUHHTHwaL5g==}
@@ -7226,6 +7232,10 @@ snapshots:
       '@types/ms': 2.1.0
 
   '@types/estree@1.0.8': {}
+
+  '@types/fluent-ffmpeg@2.1.27':
+    dependencies:
+      '@types/node': 22.17.1
 
   '@types/lodash.throttle@4.1.9':
     dependencies:


### PR DESCRIPTION
Fix Vercel build failure by adding `fluent-ffmpeg` types, allowing `ffmpeg-static` build scripts, and normalizing Node.js engine version.

---
Linear Issue: [POD-53](https://linear.app/podslice/issue/POD-53/fix-vercel-build-issue)

<a href="https://cursor.com/background-agent?bcId=bc-eab8696a-0463-4de6-94c1-00ad7e99b3e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eab8696a-0463-4de6-94c1-00ad7e99b3e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

