### PR TITLE
Add episode duration indicator to card

### DIFF
--- a/components/episode-list.tsx
+++ b/components/episode-list.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { Episode } from "@/lib/types"
 import DateIndicator from "./ui/date-indicator"
+import DurationIndicator from "./ui/duration-indicator"
 import { Body, Typography } from "./ui/typography"
 
 interface EpisodeListProps {
@@ -49,6 +50,7 @@ export const EpisodeList: React.FC<EpisodeListProps> = ({ episodes, onPlayEpisod
 
 									<Body className=" text-custom-sm text-muted-foreground episode-card-description mb-0 w-full">{episode.description || "No description available."}</Body>
 									<DateIndicator size="sm" indicator={episode.published_at || new Date()} label="Published" />
+									<DurationIndicator size="sm" seconds={episode.duration_seconds ?? null} />
 									{/* Play button - delegates to parent component */}
 									{episode.audio_url && onPlayEpisode && (
 										<div className="mt-1 ml-0 pl-0 flex-self-start w-full flex justify-start">

--- a/components/ui/duration-indicator.tsx
+++ b/components/ui/duration-indicator.tsx
@@ -1,0 +1,45 @@
+import type React from "react"
+
+interface DurationIndicatorProps {
+	seconds?: number | null
+	label?: string | null
+	size?: "xs" | "sm"
+}
+
+function formatDuration(totalSeconds?: number | null): string {
+	if (totalSeconds === null || totalSeconds === undefined) return "Unknown"
+	if (typeof totalSeconds !== "number" || Number.isNaN(totalSeconds)) return "Unknown"
+	if (totalSeconds <= 0) return "Unknown"
+
+	const hours = Math.floor(totalSeconds / 3600)
+	const minutes = Math.floor((totalSeconds % 3600) / 60)
+	const seconds = Math.floor(totalSeconds % 60)
+
+	const parts: string[] = []
+	if (hours > 0) {
+		parts.push(String(hours))
+		parts.push(String(minutes).padStart(2, "0"))
+		parts.push(String(seconds).padStart(2, "0"))
+		return parts.join(":")
+	}
+
+	// mm:ss for durations under 1 hour
+	return `${minutes}:${String(seconds).padStart(2, "0")}`
+}
+
+function DurationIndicator({ seconds, label = "Duration", size = "sm" }: DurationIndicatorProps): React.ReactElement {
+	const sizeClasses = {
+		xs: "text-[0.5rem]",
+		sm: "text-[0.6rem]",
+	}
+
+	return (
+		<div className={`mt-1 uppercase ${sizeClasses[size]} text-primary-foreground/60`}>
+			{label ? `${label}: ` : null}
+			{formatDuration(seconds)}
+		</div>
+	)
+}
+
+export default DurationIndicator
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,7 @@ model Episode {
   description   String?              @map("description")
   audio_url     String               @map("audio_url")
   image_url     String?              @map("image_url")
+  duration_seconds Int?              @map("duration_seconds")
   published_at  DateTime?            @map("published_at")
   week_nr       DateTime?            @map("week_nr")
   created_at    DateTime             @default(now()) @map("created_at")


### PR DESCRIPTION
Add episode duration indicator to episode list, wired to new `duration_seconds` field in the database.

---
<a href="https://cursor.com/background-agent?bcId=bc-df011c94-2950-456a-9b12-5ca101289ab3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df011c94-2950-456a-9b12-5ca101289ab3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

