### PR TITLE
Investigate and fix gemini video transcription

### DIFF
--- a/docs/provider-pool-implementation.md
+++ b/docs/provider-pool-implementation.md
@@ -54,7 +54,7 @@ Resolvers run in parallel within each sweep. The pool repeats sweeps periodicall
 - AssemblyAI (polling): short-interval loop up to ~90 minutes total.
 - Rev.ai (polling): similar loop.
 - Gemini video understanding: `lib/transcripts/gemini-video.ts`
-  - Uses Files API (`@google/generative-ai/server`) to upload the media (audio/YouTube-derived) and call `gemini-1.5-flash`.
+  - Uses Files API (`@google/generative-ai/server`) to upload direct media or passes YouTube URLs directly, and calls `gemini-2.5-flash`.
   - Returns a single transcript string; result logged and persisted if present.
 
 ### 5) Admin-only Debugging & Reports

--- a/lib/transcripts/gemini-video.ts
+++ b/lib/transcripts/gemini-video.ts
@@ -3,29 +3,68 @@ import { GoogleAIFileManager } from "@google/generative-ai/server"
 import { tmpdir } from "node:os"
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs"
 import path from "node:path"
+import { aiConfig } from "@/config/ai"
 
-export async function transcribeWithGeminiFromUrl(audioUrl: string): Promise<string | null> {
+export async function transcribeWithGeminiFromUrl(srcUrl: string): Promise<string | null> {
   const apiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY || process.env.GEMINI_API_KEY
   if (!apiKey) return null
   const client = new GoogleGenerativeAI(apiKey)
   const fileManager = new GoogleAIFileManager(apiKey)
 
+  const modelName = aiConfig?.geminiModel || "gemini-2.5-flash"
+  const model = client.getGenerativeModel({ model: modelName })
+  const prompt = "Transcribe this media into plain text. Return only the transcript, no timestamps or speakers."
+
+  // If it's a YouTube URL, pass it directly to the model per Gemini video understanding docs
+  const isYouTube = /(?:youtu\.be\/|youtube\.com\/)/i.test(srcUrl)
+  if (isYouTube) {
+    try {
+      const result = await model.generateContent([
+        { text: srcUrl },
+        { text: prompt },
+      ])
+      const text = result.response.text()
+      return text && text.trim().length > 0 ? text : null
+    } catch {
+      return null
+    }
+  }
+
+  // Otherwise, treat as a direct media URL; upload via Files API then call the model
+  let tempDir: string | null = null
   try {
-    // Stream fetch the audio and upload using Files API
-    const res = await fetch(audioUrl)
+    const res = await fetch(srcUrl)
     if (!res.ok) return null
-    const contentType = res.headers.get("content-type") || "audio/mpeg"
+    const contentType = res.headers.get("content-type") || "application/octet-stream"
+
+    // Avoid mistakenly uploading HTML (e.g., a watch page) as audio
+    if (contentType.includes("text/html")) {
+      return null
+    }
+
     const arrayBuffer = await res.arrayBuffer()
+    tempDir = mkdtempSync(path.join(tmpdir(), "gemini-"))
 
-    // Write to a temp file to satisfy FileManager upload API
-    const dir = mkdtempSync(path.join(tmpdir(), "gemini-"))
-    const ext = contentType.includes("wav") ? ".wav" : contentType.includes("m4a") ? ".m4a" : contentType.includes("aac") ? ".aac" : contentType.includes("flac") ? ".flac" : ".mp3"
-    const filePath = path.join(dir, `audio${ext}`)
+    // Infer extension from content-type
+    const ext = contentType.includes("wav")
+      ? ".wav"
+      : contentType.includes("m4a")
+      ? ".m4a"
+      : contentType.includes("aac")
+      ? ".aac"
+      : contentType.includes("flac")
+      ? ".flac"
+      : contentType.includes("mp4")
+      ? ".mp4"
+      : contentType.includes("webm")
+      ? ".webm"
+      : contentType.includes("mpeg") || contentType.includes("mp3")
+      ? ".mp3"
+      : ""
+
+    const filePath = path.join(tempDir, `media${ext}`)
     writeFileSync(filePath, Buffer.from(new Uint8Array(arrayBuffer)))
-    const uploaded = await fileManager.uploadFile(filePath, { mimeType: contentType, displayName: "episode-audio" })
-
-    const model = client.getGenerativeModel({ model: "gemini-1.5-flash" })
-    const prompt = "Transcribe this audio into plain text. Return only the transcript, no timestamps or speakers."
+    const uploaded = await fileManager.uploadFile(filePath, { mimeType: contentType, displayName: "episode-media" })
 
     const result = await model.generateContent([
       { fileData: { fileUri: uploaded.file.uri, mimeType: contentType } },
@@ -37,9 +76,8 @@ export async function transcribeWithGeminiFromUrl(audioUrl: string): Promise<str
   } catch {
     return null
   } finally {
-    // Best-effort cleanup
     try {
-      const base = path.dirname(path.dirname((await import("node:url")).fileURLToPath(import.meta.url))) // noop to avoid TS unused
+      if (tempDir) rmSync(tempDir, { recursive: true, force: true })
     } catch {}
   }
 }


### PR DESCRIPTION
Fix Gemini video transcription by using `gemini-2.5-flash` and directly passing YouTube URLs, resolving the 'cannot transcribe HTML' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b22b958-b534-4837-90c6-d67c7d8ad2e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b22b958-b534-4837-90c6-d67c7d8ad2e8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

